### PR TITLE
Video feeds

### DIFF
--- a/TAKfreeServer/SQLcommands.py
+++ b/TAKfreeServer/SQLcommands.py
@@ -1,6 +1,6 @@
 class sql:
     def __init__(self):
-        #querys for httpServer
+        # Statements for Data Package records. Accessed from HTTP server
         self.CREATEDPTABLE = ("CREATE TABLE IF NOT EXISTS DataPackages"
         "(PrimaryKey          INTEGER  PRIMARY KEY ON CONFLICT FAIL AUTOINCREMENT UNIQUE ON CONFLICT FAIL,"
         "UID                STRING,"
@@ -13,22 +13,37 @@ class sql:
         "MIMEType           STRING   DEFAULT [application/x-zip-compressed],"
         "Size               INTEGER,"
         "Privacy            INTEGER  DEFAULT 0);")
-
         self.MISSIONUPLOADCALLSIGN = "SELECT Callsign FROM Users WHERE UID=?"
-    
         self.INSERTDPINFO = "INSERT INTO DataPackages (UID, Name, Hash, SubmissionUser, CreatorUid, Size) VALUES(?,?,?,?,?,?);"
-
         self.ROWBYHASH = "SELECT * FROM DataPackages WHERE Hash=?"
-
         self.SELECTALLDP = "SELECT * FROM DataPackages WHERE Privacy = 0"
-    
-        #querys for server
-        self.DELETEBYUID = "DELETE FROM Users WHERE UID=?"
 
+        # Statements to work with storing/retrieving video links. Accessed from HTTP server
+        self.CREATEVIDEOTABLE = ("CREATE TABLE IF NOT EXISTS VideoLinks"
+        "(PrimaryKey         INTEGER PRIMARY KEY ON CONFLICT FAIL AUTOINCREMENT UNIQUE ON CONFLICT FAIL,"
+        "FullXmlString       STRING,"
+        "Timestamp           DATETIME DEFAULT (CURRENT_TIMESTAMP),"
+        "Protocol            STRING,"
+        "Alias               STRING,"
+        "Uid                 STRING,"
+        "Address             STRING,"
+        "Port                INTEGER DEFAULT -1,"
+        "RoverPort           INTEGER DEFAULT -1,"
+        "IgnoreEmbeddedKlv   STRING DEFAULT false,"
+        "PreferredMacAddress STRING DEFAULT NULL,"
+        "Path                STRING DEFAULT NULL,"
+        "Buffer              INTEGER DEFAULT -1,"
+        "Timeout             INTEGER,"
+        "RtspReliable        INTEGER DEFAULT 0);")
+        self.INSERTVIDEO = "INSERT INTO VideoLinks (FullXmlString,Protocol,Alias,Uid,Address,Port,RoverPort,IgnoreEmbeddedKlv,PreferredMacAddress,Path,Buffer,Timeout,RtspReliable) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"
+        self.GETALLVIDEOS = "SELECT FullXmlString FROM VideoLinks"
+        self.GETVIDEOSWITHUID = "SELECT FullXmlString from VideoLinks WHERE Uid=?"
+
+        # Statements for User records, accessed from TCP server only
         self.CREATEUSERSTABLE = ("CREATE TABLE IF NOT EXISTS Users"
         "(PrimaryKey INTEGER PRIMARY KEY ON CONFLICT FAIL AUTOINCREMENT UNIQUE ON CONFLICT FAIL,"
         "UID STRING,"
         "ID  STRING,"
         "Callsign STRING);")
-
+        self.DELETEBYUID = "DELETE FROM Users WHERE UID=?"
         self.INSERTNEWUSER = "INSERT INTO users (ID, UID, Callsign) VALUES(?, ?, ?)"

--- a/docs/Example metrics/video_feeds/example_feeds.xml
+++ b/docs/Example metrics/video_feeds/example_feeds.xml
@@ -1,0 +1,30 @@
+<videoConnections>
+	<feed>
+		<protocol>rtsp</protocol>
+		<alias>BigBuckBunny</alias>
+		<uid>1357c5e9-ff10-40eb-8b1b-35ecb8adb7db</uid>
+		<address>wowzaec2demo.streamlock.net</address>
+		<port>-1</port>
+		<roverPort>-1</roverPort>
+		<ignoreEmbeddedKLV>false</ignoreEmbeddedKLV>
+		<preferredMacAddress/>
+		<path>/vod/mp4:BigBuckBunny_115k.mov</path>
+		<buffer>-1</buffer>
+		<timeout>0</timeout>
+		<rtspReliable>0</rtspReliable>
+	</feed>
+	<feed>
+		<protocol>http</protocol>
+		<alias>Sochi, Russia</alias>
+		<uid>c779053a-2f13-4683-a643-83ec8eb2558d</uid>
+		<address>158.58.130.148</address>
+		<port>80</port>
+		<roverPort>-1</roverPort>
+		<ignoreEmbeddedKLV>false</ignoreEmbeddedKLV>
+		<preferredMacAddress/>
+		<path>/mjpg/video.mjpg</path>
+		<buffer>-1</buffer>
+		<timeout>0</timeout>
+		<rtspReliable>0</rtspReliable>
+	</feed>
+</videoConnections>


### PR DESCRIPTION
We now have the ability to push and pull video feeds (so a link to a video stream, rather than the video file itself) to and from FTS. It stores any received feeds in TAK.db and fetches them as requested by the client.

I've attached an example video configuration ([pulled from here, if you're curious](https://www.insecam.org/)) that you can use to verify, or try with any of your own IP cameras. 

![Screenshot_20200515-163641](https://user-images.githubusercontent.com/20978454/82068838-70e77a80-96ca-11ea-8105-71c218b6b9bc.jpg)
